### PR TITLE
Streaming Analytics 10.14 release notes

### DIFF
--- a/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0.md
+++ b/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0.md
@@ -13,22 +13,8 @@ in the Apama documentation.
 ### Improvements in Analytics Builder
 
 Samples are now provided in the model manager. These are similar to the smart rules in Cumulocity IoT. 
-The samples are intended to help you get started with creating your own models. You can view the samples, but you cannot edit or deploy them. 
-However, you can use a sample as a basis for further development by creating a new model from the sample. 
+The samples are intended to help you get started with creating your own models. 
+You can use a sample as a basis for further development by creating a new model from the sample. 
 You can then edit the new model according to your requirements and deploy it. 
 See also the information on the new **Samples tab** in [The model manager user interface](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fco-AnaBui_the_model_manager_user_interface.html)
 in the Analytics Builder documentation.
-
-### Cumulocity IoT transport in Apama
-
-<!-- Copied from the Misc topic of the PAM 10.11.3 release notes. -->
-<!-- For 10.13, we also copied over info from the Affecting Backwards Compatibility + Misc topics of the PAM 10.11.1 release notes, 
-but put it in the "Important Announcements" of the C8Y release notes
-However, this is now about a new property and does not break backwards compatibility.
-So I think we can put it here (provided that we also want to mention this here in the C8Y release notes) -->
-
-For configuring the Cumulocity IoT transport, a new property named `CUMULOCITY_INITIAL_DELAY_SECS` is available in Apama 10.11.3. 
-It is not provided by default in the *.properties* configuration file. You can add it if you want to set an initial delay (in seconds) for querying tenant subscriptions. 
-By default, it is set to 0 seconds. 
-See also [Configuring the Cumulocity IoT transport](https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/index.html#page/apama-webhelp%2Fco-ConApaAppToExtCom_cumulocity_configuring_the_cumulocity_transport.html) 
-in the Apama documentation.

--- a/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0.md
+++ b/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0.md
@@ -3,3 +3,32 @@ weight: 40
 title: Release 10.14.0
 layout: redirect
 ---
+
+### Apama correlator version
+
+This release of Cumulocity IoT Streaming Analytics includes the Apama version 10.11.3 correlator.
+See also [What's New In Apama 10.11.3](https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/index.html#page/apama-webhelp%2Fco-WhaNewInApa_10113_top.html)
+in the Apama documentation.
+
+### Improvements in Analytics Builder
+
+Samples are now provided in the model manager. These are similar to the smart rules in Cumulocity IoT. 
+The samples are intended to help you get started with creating your own models. You can view the samples, but you cannot edit or deploy them. 
+However, you can use a sample as a basis for further development by creating a new model from the sample. 
+You can then edit the new model according to your requirements and deploy it. 
+See also the information on the new **Samples tab** in [The model manager user interface](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fco-AnaBui_the_model_manager_user_interface.html)
+in the Analytics Builder documentation.
+
+### Cumulocity IoT transport in Apama
+
+<!-- Copied from the Misc topic of the PAM 10.11.3 release notes. -->
+<!-- For 10.13, we also copied over info from the Affecting Backwards Compatibility + Misc topics of the PAM 10.11.1 release notes, 
+but put it in the "Important Announcements" of the C8Y release notes
+However, this is now about a new property and does not break backwards compatibility.
+So I think we can put it here (provided that we also want to mention this here in the C8Y release notes) -->
+
+For configuring the Cumulocity IoT transport, a new property named `CUMULOCITY_INITIAL_DELAY_SECS` is available in Apama 10.11.3. 
+It is not provided by default in the *.properties* configuration file. You can add it if you want to set an initial delay (in seconds) for querying tenant subscriptions. 
+By default, it is set to 0 seconds. 
+See also [Configuring the Cumulocity IoT transport](https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/index.html#page/apama-webhelp%2Fco-ConApaAppToExtCom_cumulocity_configuring_the_cumulocity_transport.html) 
+in the Apama documentation.


### PR DESCRIPTION
Added information on the Apama correlator version, copied over info from the Analytics Builder release notes, and also some C8Y-specific info from the PAM 10.11.3 release notes.