### PR TITLE
PAB-3089: New Time input port

### DIFF
--- a/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0.md
+++ b/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0.md
@@ -16,5 +16,10 @@ Samples are now provided in the model manager. These are similar to the smart ru
 The samples are intended to help you get started with creating your own models. 
 You can use a sample as a basis for further development by creating a new model from the sample. 
 You can then edit the new model according to your requirements and deploy it. 
-See also the information on the new **Samples tab** in [The model manager user interface](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fco-AnaBui_the_model_manager_user_interface.html)
+See also the description of the new **Samples** tab in [The model manager user interface](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fco-AnaBui_the_model_manager_user_interface.html)
 in the Analytics Builder documentation.
+
+The [Measurement Output](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_CreateMeasurement.html) block 
+now has a new **Time** input port. This can be used to set the timestamp of the measurement and works similar to the already existing **Time** input ports of the 
+[Alarm Output](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_CreateAlarm.html) 
+and [Event Output](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_CreateEvent.html) blocks.


### PR DESCRIPTION
Copied over the release note for the new Time input port from the Analytics Builder doc at https://docbuilder1.eur.ad.sag/jenkins/job/pab/job/trunk-webhelp_en/lastSuccessfulBuild/artifact/out/webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fco-AnaBui_whats_new_1014.html
and also fixed the previous paragraph on the new samples.
Keep in mind that the links to the 10.14 Analytics Builder doc do not yet work as this has not yet been published.