### PR TITLE
PAB-3219: Release note for Analytics Builder support of globalTitle

### DIFF
--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0.md
@@ -12,6 +12,9 @@ in the Apama documentation.
 
 ### Improvements in Analytics Builder
 
+Analytics Builder now supports the `globalTitle` branding option for the category names in the model editor. 
+See also [Branding and language customization](https://cumulocity.com/guides/web/application-configuration/#branding-and-language-customization) in the *Web SDK guide*.
+
 In the previous release, the template parameter names in the Analytics Builder samples were only available in English. 
 As of this release, translations are available for the supported languages.
 


### PR DESCRIPTION
Copied over 10.15 release note from the Analytics Builder doc for support of globalTitle.