### PR TITLE
PAB-3254: Release note for 10.6.6.30 fix

### DIFF
--- a/content/release-10-6-6/streaming-analytics-10-6-6-bundle/10_6_6_30.md
+++ b/content/release-10-6-6/streaming-analytics-10-6-6-bundle/10_6_6_30.md
@@ -1,0 +1,40 @@
+---
+weight: 51
+title: Release 10.6.6.30
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.5.4.?? (which is the same as Apama 10.5.0 Fix ??).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Smart rules</td>
+<td style="text-align:left">When existing smart rules were migrated from CEL (Esper) to Apama, the implementation could create stale instances
+   if a smart rule was edited or deleted after migration. This is resolved now.</td>
+<td style="text-align:left">PAB-3252</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+
+
+

--- a/content/release-10-6-6/streaming-analytics-10-6-6-bundle/10_6_6_30.md
+++ b/content/release-10-6-6/streaming-analytics-10-6-6-bundle/10_6_6_30.md
@@ -4,7 +4,7 @@ title: Release 10.6.6.30
 layout: redirect
 ---
 
-This release upgrades the Apama-ctrl microservice to use Apama 10.5.4.?? (which is the same as Apama 10.5.0 Fix ??).
+This release upgrades the Apama-ctrl microservice to use Apama 10.5.4.10 (which is the same as Apama 10.5.0 Fix 31).
 
 ### Fixes
 


### PR DESCRIPTION
Added release note for 10.6.6.30 fix. But still need to find out the correct version numbers for Apama.