### PR TITLE
PAB-3305: Search and filter Analytics Builder samples

### DIFF
--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0.md
@@ -39,6 +39,8 @@ Additional Analytics Builder samples are now available in the model editor. The 
 Detailed descriptions have been added for the Analytics Builder samples. You can see the first lines of such a description in a tooltip when you move the mouse over the card for a sample, 
 or you can see the full description when you view a sample (or create a model from the sample) and then open the Model Configuration dialog box.
 
+It is now possible to search for Analytics Builder samples with specific words in their names and to filter them by tags.
+
 In the previous release, the template parameter names in the Analytics Builder samples were only available in English. 
 As of this release, translations are available for the supported languages.
 


### PR DESCRIPTION
Copied over from https://docbuilder1.eur.ad.sag/jenkins/job/pab/job/trunk-webhelp_en/lastSuccessfulBuild/artifact/out/webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fco-AnaBui_whats_new_1015.html that it's now possible to search for Analytics Builder samples with specific words in their names and to filter them by tags.