### PR TITLE
Release notes for the PAQ 10.13.0.3 and 10.13.0.4 fixes

### DIFF
--- a/content/release-10-13-0/streaming-analytics-10-13-0-bundle/10_13_0_3.md
+++ b/content/release-10-13-0/streaming-analytics-10-13-0-bundle/10_13_0_3.md
@@ -1,0 +1,35 @@
+---
+weight: 37
+title: Release 10.13.0.3
+layout: redirect
+---
+
+In this release, the Apama-ctrl microservice uses the same Apama version as in the previous 10.13.0.2 release. 
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Smart rules</td>
+<td style="text-align:left">When existing smart rules were migrated from CEL (Esper) to Apama, 
+  the implementation could create stale instances if a smart rule was edited or deleted after migration. 
+  This is resolved now.</td>
+<td style="text-align:left">PAB-3249</td>
+</tr>
+
+</tbody>
+</table>

--- a/content/release-10-13-0/streaming-analytics-10-13-0-bundle/10_13_0_4.md
+++ b/content/release-10-13-0/streaming-analytics-10-13-0-bundle/10_13_0_4.md
@@ -1,0 +1,34 @@
+---
+weight: 36
+title: Release 10.13.0.4
+layout: redirect
+---
+
+In this release, the Apama-ctrl microservice uses the same Apama version as in the previous 10.13.0.3 release. 
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Smart rules</td>
+<td style="text-align:left"><code>cep_proxy_request_counts</code> information in <code>health</code>, <code>prometheus</code>, <code>diagnostics/apamaCtrlStatus</code> responses 
+  and Proxy Status status lines now uses the hostnames of the core nodes instead of IP addresses.</td>
+<td style="text-align:left">PAB-3280</td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
This is for both PAB-3283 and PAB-3315, and can go live the next time the public C8Y release notes are updated.

Received developer confirmation on the iTrac that the release notes look good. 