### PR TITLE
PAB-3323: Update the links to the 10.15 PAM and PAB webhelps

### DIFF
--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0.md
@@ -7,7 +7,7 @@ layout: redirect
 ### Apama correlator version
 
 This release of Cumulocity IoT Streaming Analytics includes the Apama version 10.15.0 correlator.
-See also [What's New In Apama 10.15.0](https://documentation.softwareag.com/apama/v10-15/apama10-15/apama-webhelp/index.html#page/apama-webhelp%2Fco-WhaNewInApa_10150_top.html)
+See also [What's New In Apama 10.15.0](https://documentation.softwareag.com/pam/10.15.0/en/webhelp/pam-webhelp/index.html#page/pam-webhelp%2Fco-WhaNewInApa_10150_top.html)
 in the Apama documentation.
 
 ### Improvements for requests with concurrent connections
@@ -44,14 +44,14 @@ It is now possible to search for Analytics Builder samples with specific words i
 In the previous release, the template parameter names in the Analytics Builder samples were only available in English. 
 As of this release, translations are available for the supported languages.
 
-The [Alarm Output](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-15-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_CreateAlarm.html) 
+The [Alarm Output](https://documentation.softwareag.com/pab/10.15.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fre_AnaBui_block_reference_Output_CreateAlarm.html) 
 and 
-[Measurement Output](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-15-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_CreateMeasurement.html) 
+[Measurement Output](https://documentation.softwareag.com/pab/10.15.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fre_AnaBui_block_reference_Output_CreateMeasurement.html) 
 blocks now have a new **Params Fragment** parameter and a new **Properties** input port. 
 These can be used to set custom properties, similar to the already existing functionality of the 
-[Event Output](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-15-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_CreateEvent.html) block.
+[Event Output](https://documentation.softwareag.com/pab/10.15.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fre_AnaBui_block_reference_Output_CreateEvent.html) block.
 
-The [Alarm Output](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-15-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_CreateAlarm.html)
+The [Alarm Output](https://documentation.softwareag.com/pab/10.15.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fre_AnaBui_block_reference_Output_CreateAlarm.html)
 block now has a new **Create Asynchronous Output** parameter. It is not selected by default which reflects the block's previous behavior. 
 When selected, alarms can now be created and cleared asynchronously.
 


### PR DESCRIPTION
This is part of the changes for the automatic deployment of the DITA doc onto the doc website. The folder structure on the doc website will change for 10.15 when all docs for the October release will go live. Therefore I adapted the links to the Apama and Analytics Builder doc in the 10.15 release notes. Note that the links won't change for the webhelps of the previous versions - they remain as they are.

Unfortunately, we cannot yet check if the changed links do really work. This has to wait until the middle of October 2022.