### PR TITLE
PAQ 10.14.0.3 fix release note

### DIFF
--- a/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0_3.md
+++ b/content/release-10-14-0/streaming-analytics-10-14-0-bundle/10_14_0_3.md
@@ -1,0 +1,34 @@
+---
+weight: 37
+title: Release 10.14.0.3
+layout: redirect
+---
+
+In this release, the Apama-ctrl microservice uses the same Apama version as in the previous 10.14.0.2 release. 
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Streaming Analytics application</td>
+<td style="text-align:left">The Streaming Analytics application has been updated to use the 10.14.0.133 Web SDK. 
+  See also <a href="/release-10-14-0/applications-10-14-0/">Applications<a/>.</td>
+<td style="text-align:left">PAB-3334</td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
This can go live the next time the 10.14 release notes are updated on the public website.
Therefore, this also needs to be cherry-picked into "main" via one more PR.