### PR TITLE
Add release notes for Streaming Analytics 10.16

### DIFF
--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0.md
@@ -1,0 +1,37 @@
+---
+weight: 40
+title: Release 10.16.0
+layout: redirect
+---
+
+### Apama correlator version
+
+This release of Cumulocity IoT Streaming Analytics includes the Apama version 10.15.1 correlator.
+See also [What's New In Apama 10.15.1](https://documentation.softwareag.com/pam/10.15.1/en/webhelp/pam-webhelp/index.html#page/pam-webhelp%2Fco-WhaNewInApa_10151_top.html)
+in the Apama documentation.
+
+### Improvements in Analytics Builder
+
+The **Type** parameter of the [Selector](https://documentation.softwareag.com/pab/10.16.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fre_AnaBui_block_reference_Flow_Manipulation_Selector.html) 
+block now supports JSON for setting the type of the output value. 
+If **JSON** is selected as the type, all input parameter values must be valid JSON values of the same type.
+If the **Type** parameter remains unselected, the type of the output value is set based on the types of all input parameter values. 
+If all values are either `true` or `false`, the output is a `boolean` value. 
+If all values are numbers, the output is a `float` value. In all other cases, the output is a `string` value.
+
+The [Combiner](https://documentation.softwareag.com/pab/10.16.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fre_AnaBui_block_reference_Flow_Manipulation_Combiner.html) 
+block now offers a new mode called **Latest Updated**. When selected, it outputs the latest updated value even if the actual value is unchanged. 
+If multiple values update in a single activation, then the input port with the highest number is used. 
+For clarity, the existing **Latest** mode has been renamed to **Latest Changed**.
+
+The behavior of the [Discrete Statistics](https://documentation.softwareag.com/pab/10.16.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fre_AnaBui_block_reference_Aggregates_DiscreteStatistics.html) 
+block has been corrected. The block no longer uses the previous discrete value when the state of the block is reset. 
+If the **Sample** input port is not connected, every value is sampled. 
+If a new value is received during the same activation period as a reset, the value is now sampled after the reset, otherwise it is ignored.
+
+The value of the `timestamp` field of the `apama.analyticsbuilder.Value` event when used as an input value in a custom block was incorrect in some situations. 
+This has been fixed so that the `timestamp` field now contains the correct timestamp of the value.
+
+The following keys for configuring model timeouts have been removed and will be ignored when set: 
+`default_timeout_secs` and `block_promise_timeout_secs`. 
+Instead, warnings are now logged when request responses or returned promise values take too long to complete.


### PR DESCRIPTION
Added PAM correlator version and copied over 10.16.0 release notes from Analytics Builder doc. Need to make sure that the new URLs to the PAM and PAB doc will work (to be done later when these URLs are finally available on the doc website).