### PR TITLE
PAB-3560: Improved tooltip input and output ports

### DIFF
--- a/content/release-10-17-0/streaming-analytics-10-17-0-bundle/10_17_0.md
+++ b/content/release-10-17-0/streaming-analytics-10-17-0-bundle/10_17_0.md
@@ -55,3 +55,5 @@ This is also reflected in the Template Parameters dialog box, where you can now 
 **Multi-line String** as the type for the parameters listed above. See also
 [Managing template parameters](https://documentation.softwareag.com/pab/10.17.0/en/webhelp/pab-webhelp/index.html#page/pab-webhelp%2Fta-AnaBui_managing_template_parameters.html)
 in the Analytics Builder documentation.
+
+When you move the mouse pointer over the input or output port of a block, the description of this port is now displayed in the tooltip in addition to the port name.


### PR DESCRIPTION
Copied over release note on tooltip improvement from the Analytics Builder doc.