### PR TITLE
Revert "PAB-3674: removed roles"

### DIFF
--- a/content/release-10-18-0/announcements-10-18-0.md
+++ b/content/release-10-18-0/announcements-10-18-0.md
@@ -28,10 +28,3 @@ layout: bundle
 ### Streaming Analytics
 
 #### Implemented
-
-##### Removal of required roles from the manifest
-
-For security reasons, ROLE_APPLICATION_MANAGEMENT_ADMIN and ROLE_OPTION_MANAGEMENT_ADMIN have been
-removed from the required roles which are defined in the manifest file of the Apama-ctrl microservice.
-Any applications deployed with the Streaming Analytics application (for example, EPL apps) can no longer
-perform security-sensitive operations such as application creation or modification of tenant options.


### PR DESCRIPTION
Turns out our fix for PAB-3674 was breaking, so we've pulled the change for now, therefore it shouldn't be in the doc.