### PR TITLE
PAQ release notes for 10.15.0.6 (PAB-3699)

### DIFF
--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
@@ -1,0 +1,69 @@
+---
+weight: 34
+title: Release 10.15.0.6
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.0.7 (which is the same as Apama 10.15.2.1).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">The <code>/prometheus</code> endpoint of the Apama-ctrl microservices is now
+restricted to only the bootstrap tenant and internal monitoring from Cumulocity Ops.
+It now contains all of the metrics published by the correlator and user applications running in it.
+<!-- I still need to find out which text to use for the release note, either the above from the parent defect or the one below - or both? -->
+For reasons of security and performance, the REST endpoint <code>/service/cep/health</code> no longer returns a comprehensive list of status values.
+All of the same information is still available from REST endpoints under <code>/service/cep/diagnostics/...</code>.
+</td>
+<td style="text-align:left">PAB-3605</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">Requests from a user who is logged in using TFA were rejected when Apama-ctrl-smartrules or
+Apama-ctrl-smartrulesmt microservice backends are used. This issue has now been resolved.</td>
+<td style="text-align:left">PAB-3654</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">Requests from a user who is logged in using OAI-Secure were rejected when Apama-ctrl-smartrules or
+Apama-ctrl-smartrulesmt microservice backends are used. This issue has now been resolved.</td>
+<td style="text-align:left">PAB-3650</td>
+</tr>
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">When the <b>Create Alarm</b> block was raising a new alarm, there was a chance for duplicate events to be delivered to the worker,
+causing multiple invocations for the same input. This issue has now been resolved.</td>
+<td style="text-align:left">PAB-3636</td>
+</tr>
+<tr>
+<td style="text-align:left">EPL Apps</td>
+<td style="text-align:left">Performance optimizations have been made which should improve high-throughput measurement use cases.</td>
+<td style="text-align:left">PAB-3614</td>
+</tr>
+<tr>
+<td style="text-align:left">Smart rules</td>
+<td style="text-align:left">The smart rule implementation now handles concurrent CRUD requests with the same ID as the smart rule
+and ensures the consistency of the smart rule instances (that is, no stale smart rules instances are running).
+</td>
+<td style="text-align:left">PAB-3657</td>
+</tr>
+
+</tbody>
+</table>

--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
@@ -26,13 +26,18 @@ This release upgrades the Apama-ctrl microservice to use Apama 10.15.0.7 (which 
 <tr>
 <td style="text-align:left">Apama-ctrl microservice</td>
 <td style="text-align:left">The <code>/prometheus</code> endpoint of the Apama-ctrl microservices is now
-restricted to only the bootstrap tenant and internal monitoring from Cumulocity Ops.
+restricted to only the bootstrap tenant and internal monitoring from Cumulocity IoT Operations.
 It now contains all of the metrics published by the correlator and user applications running in it.
-<!-- I still need to find out which text to use for the release note, either the above from the parent defect or the one below - or both? -->
-For reasons of security and performance, the REST endpoint <code>/service/cep/health</code> no longer returns a comprehensive list of status values.
-All of the same information is still available from REST endpoints under <code>/service/cep/diagnostics/...</code>.
 </td>
 <td style="text-align:left">PAB-3605</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">For reasons of security and performance, the REST endpoint
+<code>/service/cep/health</code> no longer returns a comprehensive list of status values.
+All of the same information is still available from REST endpoints under <code>/service/cep/diagnostics/...</code>.
+</td>
+<td style="text-align:left">PAB-????</td>
 </tr>
 <tr>
 <td style="text-align:left">Apama-ctrl microservice</td>

--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
@@ -37,10 +37,10 @@ It now contains all of the metrics published by the correlator and user applicat
 <code>/service/cep/health</code> no longer returns a comprehensive list of status values.
 All of the same information is still available from REST endpoints under <code>/service/cep/diagnostics/...</code>.
 </td>
-<td style="text-align:left">PAB-????</td>
+<td style="text-align:left">PAB-3526</td>
 </tr>
 <tr>
-<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">Apama-ctrl mcroservice</td>
 <td style="text-align:left">Requests from a user who is logged in using TFA were rejected when Apama-ctrl-smartrules or
 Apama-ctrl-smartrulesmt microservice backends are used. This issue has now been resolved.</td>
 <td style="text-align:left">PAB-3654</td>

--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_6.md
@@ -40,7 +40,7 @@ All of the same information is still available from REST endpoints under <code>/
 <td style="text-align:left">PAB-3526</td>
 </tr>
 <tr>
-<td style="text-align:left">Apama-ctrl mcroservice</td>
+<td style="text-align:left">Apama-ctrl microservice</td>
 <td style="text-align:left">Requests from a user who is logged in using TFA were rejected when Apama-ctrl-smartrules or
 Apama-ctrl-smartrulesmt microservice backends are used. This issue has now been resolved.</td>
 <td style="text-align:left">PAB-3654</td>


### PR DESCRIPTION
This will replace https://github.com/SoftwareAG/c8y-releasenotes/pull/177.

@skom-sag  and @ddfourni1 , I still need to know which text to use for PAB-3605 (see also my comment in the release note and Sharon's mail thread).