### PR TITLE
Release notes for PAQ 10.16.0.2 and 10.16.0.3 fixes

### DIFF
--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_2.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_2.md
@@ -26,7 +26,7 @@ This release upgrades the Apama-ctrl microservice to use Apama 10.15.2.1 (which 
 <tr>
 <td style="text-align:left">Apama-ctrl microservice</td>
 <td style="text-align:left">The <code>/prometheus</code> endpoint of the Apama-ctrl microservices is now
-restricted to only the bootstrap tenant and internal monitoring from Cumulocity IoT Operations.
+restricted to only the bootstrap tenant and internal monitoring from Cumulocity IoT operations.
 It now contains all of the metrics published by the correlator and user applications running in it.
 </td>
 <td style="text-align:left">PAB-3606</td>

--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_2.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_2.md
@@ -1,0 +1,65 @@
+---
+weight: 38
+title: Release 10.16.0.2
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.2.1 (which is the same as Apama 10.15.0.7).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">The <code>/prometheus</code> endpoint of the Apama-ctrl microservices is now
+restricted to only the bootstrap tenant and internal monitoring from Cumulocity IoT Operations.
+It now contains all of the metrics published by the correlator and user applications running in it.
+</td>
+<td style="text-align:left">PAB-3606</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">Requests from a user who is logged in using TFA were rejected when Apama-ctrl-smartrules or
+Apama-ctrl-smartrulesmt microservice backends are used. This issue has now been resolved.</td>
+<td style="text-align:left">PAB-3655</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">Requests from a user who is logged in using OAI-Secure were rejected when Apama-ctrl-smartrules or
+Apama-ctrl-smartrulesmt microservice backends are used. This issue has now been resolved.</td>
+<td style="text-align:left">PAB-3651</td>
+</tr>
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">When the <b>Create Alarm</b> block was raising a new alarm, there was a chance for duplicate events to be delivered to the worker,
+causing multiple invocations for the same input. This issue has now been resolved.</td>
+<td style="text-align:left">PAB-3637</td>
+</tr>
+<tr>
+<td style="text-align:left">EPL Apps</td>
+<td style="text-align:left">Performance optimizations have been made which should improve high-throughput measurement use cases.</td>
+<td style="text-align:left">PAB-3615</td>
+</tr>
+<tr>
+<td style="text-align:left">Smart rules</td>
+<td style="text-align:left">The smart rule implementation now handles concurrent CRUD requests with the same ID as the smart rule
+and ensures the consistency of the smart rule instances (that is, no stale smart rules instances are running).
+</td>
+<td style="text-align:left">PAB-3658</td>
+</tr>
+</tbody>
+</table>

--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_3.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_3.md
@@ -1,0 +1,43 @@
+---
+weight: 37
+title: Release 10.16.0.3
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.2.3 (which is the same as Apama 10.15.0.9).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">Deploying a model in test mode and then undeploying it could fail and could cause failures for other model deployments
+if another model with the same output blocks was already deployed in production mode and formed a chain with another already deployed model.
+This issue has now been resolved.</td>
+<td style="text-align:left">PAB-3666</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama runtime</td>
+<td style="text-align:left">Starting with 10.16, the Cumulocity IoT platform performs more strict validations on incoming fields of email requests.
+When the <code>bcc</code> field of the <code>com.apama.cumulocity.SendEmail</code> event was empty,
+the Apama HTTP client transport for Cumulocity IoT incorrectly forwarded the <code>bcc</code> field as an empty string
+instead of as a JSON array, causing requests to be rejected. This issue has now been resolved.</td>
+<td style="text-align:left">PAM-34264</td>
+</tr>
+
+</tbody>
+</table>

--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_3.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_3.md
@@ -32,7 +32,7 @@ This issue has now been resolved.</td>
 </tr>
 <tr>
 <td style="text-align:left">Apama runtime</td>
-<td style="text-align:left">Starting with 10.16, the Cumulocity IoT platform performs more strict validations on incoming fields of email requests.
+<td style="text-align:left">Starting with release 10.16, the Cumulocity IoT platform performs more strict validations on incoming fields of email requests.
 When the <code>bcc</code> field of the <code>com.apama.cumulocity.SendEmail</code> event was empty,
 the Apama HTTP client transport for Cumulocity IoT incorrectly forwarded the <code>bcc</code> field as an empty string
 instead of as a JSON array, causing requests to be rejected. This issue has now been resolved.</td>


### PR DESCRIPTION
The release notes for 10.16.0.2 and 10.16.0.3 can both go live when https://itrac.eur.ad.sag/browse/PAB-3949 moves to RELEASED-CONTROLLED.