### PR TITLE
PAB-4009: 10.18 release note for Alarm Output block

### DIFF
--- a/content/release-10-18-0/streaming-analytics-10-18-0-bundle/10_18_0.md
+++ b/content/release-10-18-0/streaming-analytics-10-18-0-bundle/10_18_0.md
@@ -51,12 +51,19 @@ Functional(sequenceIDs)
                  .onTimeout(TIMEOUTSECS, onTimeout);
 ```
 
-For detailed information, see [Using Functional Operations in EPL](https://documentation.softwareag.com/pam/10.15.3/en/webhelp/pam-webhelp/index.html#page/pam-webhelp%2Fco-DevApaAppInEpl_using_functional_operations_in_epl.html). 
+For detailed information, see [Using Functional Operations in EPL](https://documentation.softwareag.com/pam/10.15.3/en/webhelp/pam-webhelp/index.html#page/pam-webhelp%2Fco-DevApaAppInEpl_using_functional_operations_in_epl.html).
 See also the [API Reference for EPL (ApamaDoc)](https://documentation.softwareag.com/pam/10.15.3/en/webhelp/related/ApamaDoc/index.html) for detailed information on `com.apama.functional`.
 
 ### Improvements in Analytics Builder
 
-The **Cron Timer** block now has a **Time Zone** parameter to customize which time zone this block is relative to.
+The [Cron Timer](https://cumulocity.com/guides/10.18.0/streaming-analytics/block-reference/#cron-timer) block
+now has a **Time Zone** parameter to customize which time zone this block is relative to.
+
+The [Alarm Output](https://cumulocity.com/guides/10.18.0/streaming-analytics/block-reference/#alarm-output) block
+has been improved to respect alarms that are set to the "Acknowledged" status.
+By default, acknowledged alarms are now only reactivated if the severity has increased.
+This also ensures that the alarm count is updated correctly.
+To always activate alarms triggered by the model, select the new **Always Activate Alarm** parameter in the **Alarm Output** block.
 
 ### First-time activation of Analytics Builder
 
@@ -81,7 +88,8 @@ In some circumstances, Analytics Builder must be activated by the user before it
 
 <tr>
 <td style="text-align:left">Analytics Builder</td>
-<td style="text-align:left">The <b>Latch Values</b> block did not start disabled when the <b>Enable</b> input port was connected,
+<td style="text-align:left">The <a href="https://cumulocity.com/guides/10.18.0/streaming-analytics/block-reference/#latch-values">Latch Values<a/> block
+did not start disabled when the <b>Enable</b> input port was connected,
 which meant that it generated a pulse signal on the <b>Disabled</b> output port on the first false <b>Value</b> input, which it should not.
 This has now been fixed.
 The <b>Enabled</b> output port of the <b>Latch Values</b> block generates a pulse signal when the block is enabled but was previously disabled.


### PR DESCRIPTION
In addition to the new release note, I've also added links to the block reference which is now part of the Streaming Analytics guide.