### PR TITLE
PAB-4007: Update existing release note about Machine Learning deprecation 

### DIFF
--- a/content/release-10-17-0/announcements-10-17-0.md
+++ b/content/release-10-17-0/announcements-10-17-0.md
@@ -184,10 +184,10 @@ As announced with [release 10.15](/release-10-15-0/announcements-10-15-0) and [r
 
 ##### Deprecation of Machine Learning
 
-The Machine Learning block in Analytics Builder is deprecated and will be removed in a future release.
+As announced with [release 10.16](/release-10-16-0/announcements-10-16-0), the **Machine Learning** block in Analytics Builder is deprecated and will be removed in a future release.
 In addition, the EPL Apps sample "Call another microservice" which uses the Zementis microservice, has been renamed to "Call Zementis microservice".
 This sample is now deprecated and will also be removed in a future release.
-This is in line with the deprecation of [Machine Learning Engine](#machine-learning-deprecation).
+This is in line with the deprecation of [Machine Learning Engine](/release-10-16-0/announcements-10-16-0/#machine-learning-deprecation) announced in release 10.16.
 
 #### Implemented
 

--- a/content/release-10-17-0/announcements-10-17-0.md
+++ b/content/release-10-17-0/announcements-10-17-0.md
@@ -182,9 +182,12 @@ As announced with [release 10.15](/release-10-15-0/announcements-10-15-0) and [r
 
 #### Planned
 
-##### Analytics Builder - Deprecation of Machine Learning
+##### Deprecation of Machine Learning
 
-The Machine Learning block for Analytics Builder is deprecated and will be removed in a future release. This is in line with the deprecation of [Machine Learning Engine](#machine-learning-deprecation).
+The Machine Learning block in Analytics Builder is deprecated and will be removed in a future release.
+In addition, the EPL Apps sample "Call another microservice" which uses the Zementis microservice, has been renamed to "Call Zementis microservice".
+This sample is now deprecated and will also be removed in a future release.
+This is in line with the deprecation of [Machine Learning Engine](#machine-learning-deprecation).
 
 #### Implemented
 

--- a/content/release-10-18-0/announcements-10-18-0.md
+++ b/content/release-10-18-0/announcements-10-18-0.md
@@ -143,6 +143,15 @@ As announced with [release 10.17](/release-10-17-0/announcements-10-17-0), with 
 
 ### Streaming Analytics
 
+#### Planned
+
+##### Deprecation of Machine Learning
+
+As announced with [release 10.16](/release-10-16-0/announcements-10-16-0), the **Machine Learning** block in Analytics Builder is deprecated and will be removed in a future release.
+In addition, the EPL Apps sample "Call another microservice" which uses the Zementis microservice, has been renamed to "Call Zementis microservice".
+This sample is now deprecated and will also be removed in a future release.
+This is in line with the deprecation of [Machine Learning Engine](/release-10-16-0/announcements-10-16-0/#machine-learning-deprecation) announced in release 10.16.
+
 #### Implemented
 
 ##### Removal of required roles from the manifest


### PR DESCRIPTION
Hi @BeateRixen , I need your advice. I have been asked to add exactly the same release note to 10.18 (PAB-4004). Is this something that we normally do? Or is it sufficient to mention this only once, that is, in 10.17 where I've just updated the release note (done with this PR)?