### PR TITLE
PAQ: New EPL sample named "Receive update notifications" (PAB-1663)

### DIFF
--- a/content/release-2024-0/streaming-analytics-2024-0-bundle/2024_0.md
+++ b/content/release-2024-0/streaming-analytics-2024-0-bundle/2024_0.md
@@ -1,0 +1,15 @@
+---
+weight: 40
+title: Release 2024.0
+layout: redirect
+---
+
+### New EPL sample
+
+A new EPL sample named "Receive update notifications"
+can now be accessed from the EPL editor of the Streaming Analytics application.
+It shows how to write an EPL app that can distinguish between notifications for creating and updating managed objects, measurements, alarms, events, and operations.
+See also [Developing apps with the Streaming Analytics application](https://cumulocity.com/guides/10.19.0/streaming-analytics/epl-apps/#epl-apps)
+in the *Streaming Analytics* guide.
+
+For more detailed information, see [Receiving update notifications](https://documentation.softwareag.com/pam/10.15.3/en/webhelp/pam-webhelp/index.html#page/pam-webhelp%2Fco-ConApaAppToExtCom_cumulocity_receiving_update_notifications.html) in the Apama documentation for the Cumulocity IoT transport connectivity plug-in.

--- a/content/release-2024-0/streaming-analytics-2024-0-bundle/index.html
+++ b/content/release-2024-0/streaming-analytics-2024-0-bundle/index.html
@@ -1,0 +1,4 @@
+---
+title: 10.18.0
+headless: true
+---

--- a/content/release-2024-0/streaming-analytics-2024-0.md
+++ b/content/release-2024-0/streaming-analytics-2024-0.md
@@ -1,0 +1,6 @@
+---
+weight: 70
+title: Streaming Analytics
+layout: bundle
+---
+


### PR DESCRIPTION
Added the bundle for Streaming Analytics release notes to collect the PAQ changes. Did this in the "old" way for now. This can still be changed later when it has finally been decided how the release notes for CD are to look like.

Note that the link to the Streaming Analytics guide has 10.19 in the URL for now. This needs to be changed later - globally - when the final URL for the 10.18+ (CD) user doc is known.