### PR TITLE
Release notes for PAQ 10.18.0.2 (PAB-4114)

### DIFF
--- a/content/release-10-18-0/streaming-analytics-10-18-0-bundle/10_18_0_2.md
+++ b/content/release-10-18-0/streaming-analytics-10-18-0-bundle/10_18_0_2.md
@@ -1,0 +1,61 @@
+---
+weight: 38
+title: Release 10.18.0.2
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.3.1 (which is the same as Apama 10.15 Fix 12).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">The <b>Expression</b> block now calculates the remainder of integer division, as already documented.</td>
+<td style="text-align:left">PAB-4110</td>
+</tr>
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">The usability of the multi-line text area has been improved.
+It now automatically expands as you type. You no longer have to press Enter to start a new line.</td>
+<td style="text-align:left">PAB-4075</td>
+</tr>
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">A regression in 10.18.0.0 throws an error on adding an Analytics Builder block in the model editor that derives its label from an input parameter
+(for example, an <b>Alarm Input</b> block that derives its label from the <b>Alarm Type</b> parameter). This has now been fixed.</td>
+<td style="text-align:left">PAB-4081</td>
+</tr>
+<tr>
+<td style="text-align:left">Analytics Builder Block SDK</td>
+<td style="text-align:left">Fixed an issue with the test framework of the Analytics Builder Block SDK throwing a <code>UnicodeDecodeError</code> exception.</td>
+<td style="text-align:left">PAB-4084</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama runtime</td>
+<td style="text-align:left">The version of Woodstox-core has been upgraded from 6.3.0 to 6.5.0.</td>
+<td style="text-align:left">PAM-34355</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama runtime</td>
+<td style="text-align:left">The version of Java included in the Docker images has been updated to 11.0.19 to resolve security issues.</td>
+<td style="text-align:left">PAM-34361</td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
When these fix release notes are ok/approved, they also need to be copied over into the 10.18 (!) release notes in content\release-10-17-0\streaming-analytics-10-17-0-bundle.

Also required: cherry-picking from develop into the corresponding release branches - therefore need separate commits for 10.18 and 10.17.