### PR TITLE
Release notes for the 10.18.0.3 fix (PAB-4160)

### DIFF
--- a/content/release-10-17-0/streaming-analytics-10-17-0-bundle/10_18_0_3.md
+++ b/content/release-10-17-0/streaming-analytics-10-17-0-bundle/10_18_0_3.md
@@ -1,0 +1,31 @@
+---
+weight: 37
+title: Release 10.18.0.3
+layout: redirect
+---
+
+In this release, the Apama-ctrl microservice uses the same Apama version as in the previous 10.18.0.2 release.
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">Analytics Builder and EPL Apps</td>
+<td style="text-align:left">The final translations for the supported languages have been added.</td>
+<td style="text-align:left">PAB-4049</td>
+</tr>
+</tbody>
+</table>

--- a/content/release-10-18-0/streaming-analytics-10-18-0-bundle/10_18_0_3.md
+++ b/content/release-10-18-0/streaming-analytics-10-18-0-bundle/10_18_0_3.md
@@ -1,0 +1,31 @@
+---
+weight: 37
+title: Release 10.18.0.3
+layout: redirect
+---
+
+In this release, the Apama-ctrl microservice uses the same Apama version as in the previous 10.18.0.2 release.
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">Analytics Builder and EPL Apps</td>
+<td style="text-align:left">The final translations for the supported languages have been added.</td>
+<td style="text-align:left">PAB-4049</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
Also needs to be copied to /release-10-17-0/streaming-analytics-10-17-0-bundle when the 10.18 release note has been approved by the dev team.