### PR TITLE
Publish fix release note for 10.15.0.9 (PAB-4162)

### DIFF
--- a/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_9.md
+++ b/content/release-10-15-0/streaming-analytics-10-15-0-bundle/10_15_0_9.md
@@ -1,0 +1,42 @@
+---
+weight: 31
+title: Release 10.15.0.9
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.3.1 (which is the same as Apama 10.15 Fix 12).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">The <b>Alarm Output</b> block in Analytics Builder no longer reactivates "Acknowledged"
+alarms with every modification.
+Acknowledged alarms are only reactivated if the severity has increased.
+This also ensures that the alarm count is updated correctly.</td>
+<td style="text-align:left">PAB-4026</td>
+</tr>
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">The <b>Expression</b> block now calculates the remainder of integer division, as already documented.
+Previously, this functionality was not implemented and raised a runtime error if defined.</td>
+<td style="text-align:left">PAB-4107</td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
(cherry picked from commit 24bf123ffb484aa02e02e0a5a4a2043d6a1166d4)

To go live when 10.15.0.9 reaches the last column at
https://pages.github.softwareag.com/IOTA/c8y-iot-build-pipeline/10.15.0.x.html
(maybe by the end of this week or later)

