### PR TITLE
Publish fix release note for 10.16.0.5 (PAB-4161)

### DIFF
--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_5.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_5.md
@@ -1,0 +1,34 @@
+---
+weight: 35
+title: Release 10.16.0.5
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.3.1 (which is the same as Apama 10.15 Fix 12).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">The <b>Expression</b> block now calculates the remainder of integer division, as already documented.
+Previously, this functionality was not implemented and raised a runtime error if defined.</td>
+<td style="text-align:left">PAB-4108</td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
(cherry picked from commit fc966ff870dfc0fc55216e03240846e2a1122feb)

To go live when 10.16.0.5 reaches the last column at
https://pages.github.softwareag.com/IOTA/c8y-iot-build-pipeline/10.16.0.x.html
(maybe by the end of this week or later)