### PR TITLE
PAQ: Breaking change for acknowledged alarms

### DIFF
--- a/content/release-10-17-0/announcements-10-17-0.md
+++ b/content/release-10-17-0/announcements-10-17-0.md
@@ -262,6 +262,11 @@ As announced with [release 10.16](/release-10-16-0/announcements-10-16-0), the E
 It has been replaced by a new "Call another microservice" sample which now uses the `/health` endpoint of an Apama-ctrl microservice.
 See also [Connecting Apama to other microservices](https://cumulocity.com/guides/10.17.0/streaming-analytics/epl-apps/#microservices) in the *Streaming Analytics guide*.
 
+##### Breaking change in Analytics Builder - Acknowledged alarms
+
+The [Alarm Output](https://cumulocity.com/guides/10.17.0/streaming-analytics/block-reference/#alarm-output) block
+no longer reactivates "Acknowledged" alarms with every modification.
+See also the fix release note for [10.16.0.4](/release-10-16-0/streaming-analytics-10-16-0/#10_16_0_4).
 
 ##### Analytics Builder - Change of type for Clear Alarm input port
 

--- a/content/release-10-18-0/announcements-10-18-0.md
+++ b/content/release-10-18-0/announcements-10-18-0.md
@@ -98,13 +98,13 @@ Note that the administrator will still have the option to force the user to rese
 #### Planned
 
 ##### Breaking change: Use of Linux cgroup v2
-As announced with [release 10.17](/release-10-17-0/announcements-10-17-0), from release 2024, microservices must use a Linux cgroup v2 aware application runtime. When executing microservices which are not compatible with cgroup v2 on Cumulocity IoT in a version higher than 10.18 it might happen that the information provided by the application runtime concerning available CPU and memory is not correct. This might lead to incorrect memory and thread allocation in the microservice container process. 
+As announced with [release 10.17](/release-10-17-0/announcements-10-17-0), from release 2024, microservices must use a Linux cgroup v2 aware application runtime. When executing microservices which are not compatible with cgroup v2 on Cumulocity IoT in a version higher than 10.18 it might happen that the information provided by the application runtime concerning available CPU and memory is not correct. This might lead to incorrect memory and thread allocation in the microservice container process.
 
-cgroup is a Linux kernel feature to organize processes hierarchically and distribute system resources along the hierarchy in a controlled and configurable manner. Every process in the system belongs to one and only one cgroup. In Cumulocity IoT cgroups are used to enforce container resource limits. 
+cgroup is a Linux kernel feature to organize processes hierarchically and distribute system resources along the hierarchy in a controlled and configurable manner. Every process in the system belongs to one and only one cgroup. In Cumulocity IoT cgroups are used to enforce container resource limits.
 Starting with Cumulocity IoT release 2024, it will be necessary for all microservices to be compatible with Linux cgroup v2. This updated version brings significant improvements and enhanced functionality for resource management and isolation, ensuring better performance and scalability of your applications. Linux cgroup v2 was released with kernel version 4.5 in March 2016.
 
 When using the Cumulocity IoT Microservice SDK for developing microservices, ensure to configure a Java version which is cgroup v2 aware when building your microservice. When using Java 8, ensure to use openjdk8u372 or higher. When using Java 11, use Java 11.0.16 or higher, or use Java 15 or higher.
-When using a server runtime other than OpenJDK Java as microservice application runtime, refer to the documentation of the provider. 
+When using a server runtime other than OpenJDK Java as microservice application runtime, refer to the documentation of the provider.
 
 
 ### SDK changes
@@ -198,6 +198,12 @@ The German version of the Analytics Builder documentation, which is available as
 We will focus on our high-quality, up-to-date English user documentation.
 The English version of the Analytics Builder documentation has been integrated into the Cumulocity IoT documentation.
 See also [Restructured Streaming Analytics guide](/release-10-18-0/streaming-analytics-10-18-0/).
+
+##### Breaking change in Analytics Builder - Acknowledged alarms
+
+The [Alarm Output](https://cumulocity.com/guides/10.18.0/streaming-analytics/block-reference/#alarm-output) block
+no longer reactivates "Acknowledged" alarms with every modification.
+See also the fix release note for [10.16.0.4](/release-10-16-0/streaming-analytics-10-16-0/#10_16_0_4).
 
 ##### Analytics Builder - Change of type for Clear Alarm input port
 
@@ -311,4 +317,3 @@ In a future release of Cumulocity IoT DataHub the access to PowerBI reports from
 ###### Deprecation of support for mixed types
 
 As announced with [release 10.15](/release-10-15-0/announcements-10-15-0), Cumulocity IoT DataHub removes support for mixed data types. Cumulocity IoT DataHub will not be able to read data lake tables containing mixed data types, so corresponding data needs to be converted.
-


### PR DESCRIPTION
This also needs to be copied over into the 10.18 release notes.
And the 10.17 release note needs to be cherry-picked so that it can go live.