### PR TITLE
[NO-JIRA] Deprecation of HDFS support in DataHub

### DIFF
--- a/content/release-10-17-0/announcements-10-17-0.md
+++ b/content/release-10-17-0/announcements-10-17-0.md
@@ -362,6 +362,10 @@ In future releases of Cumulocity IoT DataHub the offloading mechanism may levera
 
 In a future release of Cumulocity IoT core the history attribute will be removed from the alarms. Therefore, Cumulocity IoT DataHub does no longer include this column in newly defined offloadings. If alarms data has been already offloaded into the data lake, the Dremio table associated with that data lake table still includes the history column, but for new offloading runs the value will not be included anymore and thus will be null.
 
+##### Deprecation of HDFS support
+
+In a future release of Cumulocity IoT DataHub the use of HDFS as data lake will be removed. Instead of HDFS, one of the other supported data lakes must be used.
+
 ### Cumulocity IoT Machine Learning
 
 #### Planned

--- a/content/release-10-18-0/announcements-10-18-0.md
+++ b/content/release-10-18-0/announcements-10-18-0.md
@@ -306,6 +306,10 @@ In a future release of Cumulocity IoT core the history attribute will be removed
 
 In a future release of Cumulocity IoT DataHub the access to PowerBI reports from within the Cumulocity IoT DataHub UI may be removed. Comparable functionality can be integrated into the core UI based on a PowerBI extension.
 
+##### Deprecation of HDFS support
+
+In a future release of Cumulocity IoT DataHub the use of HDFS as data lake will be removed. Instead of HDFS, one of the other supported data lakes must be used.
+
 #### Implemented
 
 ###### Deprecation of support for mixed types


### PR DESCRIPTION
Hi,

can you pls review and merge to develop, 10.18, and 10.17? For the latter merge the changes to the 10.18 announcements file can be ignored.

Thanks!