### PR TITLE
PAB-4223: Release note for removal of actions menu in Template Parameters dialog

### DIFF
--- a/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
+++ b/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
@@ -22,7 +22,10 @@ For more detailed information, see [Receiving update notifications](https://docu
 
 The [Constant Value](https://cumulocity.com/guides/10.19.0/streaming-analytics/block-reference/#constant-value) block now supports `float` and `boolean` value types
 and can produce output of these types. This enables the block's output to be consumed by other blocks that take input of type `float` or `boolean` like the blocks in
-the **Logic** and **Aggregate** categories. The **Type** parameter is also now optional. If a type is not selected, the type of the output value is inferred from the **Value** parameter. 
+the **Logic** and **Aggregate** categories. The **Type** parameter is also now optional. If a type is not selected, the type of the output value is inferred from the **Value** parameter.
+
+An icon is now provided for removing a template parameter from the **Template Parameter** dialog box.
+The actions menu (the three vertical dots at the end of a row) has therefore been removed. See also [Managing template parameters](https://cumulocity.com/docs/streaming-analytics/analytics-builder/#managing-template-parameters) in the *Streaming Analytics* guide.
 
 ### Fixes
 


### PR DESCRIPTION
@BeateRixen , I'm not sure if we still want to mention "in the *Streaming Analytics* guide" in the release notes. I added it for consistency with previous release notes - because I saw that it has not yet been removed from your other PR #303.