### PR TITLE
Copy over PAQ 10.18.0.4 release note into 10.17

### DIFF
--- a/content/release-10-17-0/streaming-analytics-10-17-0-bundle/10_18_0_4.md
+++ b/content/release-10-17-0/streaming-analytics-10-17-0-bundle/10_18_0_4.md
@@ -1,0 +1,40 @@
+---
+weight: 36
+title: Release 10.18.0.4
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.3.3 (which is the same as Apama 10.15 Fix 14).
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">When subscribed to a tenant without the core Smartrule microservice subscribed, Apama-ctrl's logging about this problem would be excessively verbose. Though this is not a recommended configuration for a tenant, Apama-ctrl's logging is now more moderate in this situation.</td>
+<td style="text-align:left">PAB-4228</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama runtime</td>
+<td style="text-align:left">The Cumulocity IoT Java SDK has been upgraded to v1015.0.456 to fix an issue where subscriptions for real-time notifications were lost when switching between Cumulocity IoT core nodes.</td>
+<td style="text-align:left">PAM-34476</td>
+</tr>
+<tr>
+<td style="text-align:left">Apama runtime</td>
+<td style="text-align:left">More information has been added to Cumulocity IoT long-running query messages, as well as for distinguishing between queries and batches.</td>
+<td style="text-align:left">PAM-34326</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
The PAQ 10.18.0.4 release note also needs to be added to the 10.17 release train.