### PR TITLE
[no-issue] remove npm workaround announcement

### DIFF
--- a/content/release-10-18+/announcements-10-18+.md
+++ b/content/release-10-18+/announcements-10-18+.md
@@ -164,19 +164,6 @@ This change will be implemented after a 3-month period at the earliest.
 
 #### Implemented
 
-##### Node package registry for Web SDK
-
-Since August, 1st 2023, we are unable to publish new releases of the Web SDK package `@c8y/ngx-components` due to an ongoing issue with npm.
-Until the issue with npm is resolved, the node packages can be loaded from another registry.
-To configure this additional registry for the packages prefixed with `@c8y`, a file with the name `.npmrc` and the following content must be present in your project directory:
-```
-registry=https://registry.npmjs.org/
-@c8y:registry=https://download.cumulocity.com/npm/
-```
-
-The scaffolding process via `c8ycli` will already include this additional file depending on the version that you use.
-Note that this is only a temporary workaround until the issue with the npm registry has been resolved.
-
 ##### Removal of deprecated device-grid model classes, column implementations and services
 
 As announced earlier, most recently with [release 10.17](/release-10-17-0/announcements-10-17-0), shared classes, components and services from the @c8y/ngx-components/device-grid are deprecated. Those deprecated items are removed with this release.

--- a/content/release-10-18-0/announcements-10-18-0.md
+++ b/content/release-10-18-0/announcements-10-18-0.md
@@ -172,19 +172,6 @@ The HOOK_SEARCH can be used by developers to extend the web integration of the s
 
 #### Implemented
 
-##### Node package registry for Web SDK
-
-Since August, 1st 2023, we are unable to publish new releases of the Web SDK package `@c8y/ngx-components` due to an ongoing issue with npm.
-Until the issue with npm is resolved, the node packages can be loaded from another registry.
-To configure this additional registry for the packages prefixed with `@c8y`, a file with the name `.npmrc` and the following content must be present in your project directory:
-```
-registry=https://registry.npmjs.org/
-@c8y:registry=https://download.cumulocity.com/npm/
-```
-
-The scaffolding process via `c8ycli` will already include this additional file depending on the version that you use.
-Note that this is only a temporary workaround until the issue with the npm registry has been resolved.
-
 ##### Breaking change in the Map widget
 
 As announced with [release 10.17](/release-10-17-0/announcements-10-17-0), the "Map" widget has been migrated and support for real-time updates on all devices has been replaced by a configurable refresh interval. This change allows us to display more then 100 devices on the map by default. Additionally, the "Map" widget no longer supports the "show track" option.


### PR DESCRIPTION
As the issue with npm has been resolved we can remove this announcement again.