### PR TITLE
PAB-4299: Missing device in a group is now ignored

### DIFF
--- a/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
+++ b/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
@@ -55,7 +55,7 @@ See also [Adding a selection list for a template parameter](https://cumulocity.c
 
 #### Missing subassets in a device group or asset hierarchy
 
-Previously, an error was thrown for an active model if a subasset of a device group or asset hierarchy no longer existed in the inventory, for example, because a device was deleted.
+Previously, when activating a model, an error was thrown if a subasset of a device group or asset hierarchy no longer existed in the inventory, for example, because a device was deleted.
 As of this version, missing subassets in a device group or asset hierarchy are ignored and an error is no longer thrown.
 However, if the deletion of a subasset results in an empty device group or asset hierarchy, an error is still thrown.
 

--- a/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
+++ b/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
@@ -53,6 +53,11 @@ You can now create a selection list for an Analytics Builder template parameter.
 You can define selection lists for types such as string, float, source or destination, or geofence and you can also select a specific value to be the default value. The values that you define for a selection list are then available for selection when you create instances of the model.
 See also [Adding a selection list for a template parameter](https://cumulocity.com/docs/streaming-analytics/analytics-builder/#adding-a-selection-list-for-a-template-parameter) in the user documentation.
 
+#### Missing subassets in a group
+
+Previously, an error was thrown for an active model if a subasset of a group no longer existed in the inventory, for example, because a device was deleted.
+As of this version, missing subassets in a group are ignored and an error is no longer thrown.
+
 ### Cumulocity IoT transport in Apama 10.15.4
 
 Range-based queries (such as `FindManagedObject`) attempt to retrieve all resources matching the query parameters by default. Explicitly setting a value for `currentPage` or setting `withTotalPages` to false can improve the query performance by disabling paging. See the information on REST usage and query result paging in the [Cumulocity IoT OpenAPI Specifications](https://cumulocity.com/api/core/#section/REST-implementation/REST-usage) for more information.

--- a/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
+++ b/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
@@ -55,7 +55,7 @@ See also [Adding a selection list for a template parameter](https://cumulocity.c
 
 #### Missing subassets in a device group or asset hierarchy
 
-Previously, when activating a model, an error was thrown if a subasset of a device group or asset hierarchy no longer existed in the inventory, for example, because a device was deleted.
+Previously, when reactivating a model, an error was thrown if a subasset of a device group or asset hierarchy from which the model receives events no longer existed in the inventory, for example, because a device was deleted.
 As of this version, missing subassets in a device group or asset hierarchy are ignored and an error is no longer thrown.
 However, if the deletion of a subasset results in an empty device group or asset hierarchy, an error is still thrown.
 

--- a/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
+++ b/content/release-10-18+/streaming-analytics-10-18+-bundle/10.18+_0.md
@@ -53,10 +53,11 @@ You can now create a selection list for an Analytics Builder template parameter.
 You can define selection lists for types such as string, float, source or destination, or geofence and you can also select a specific value to be the default value. The values that you define for a selection list are then available for selection when you create instances of the model.
 See also [Adding a selection list for a template parameter](https://cumulocity.com/docs/streaming-analytics/analytics-builder/#adding-a-selection-list-for-a-template-parameter) in the user documentation.
 
-#### Missing subassets in a group
+#### Missing subassets in a device group or asset hierarchy
 
-Previously, an error was thrown for an active model if a subasset of a group no longer existed in the inventory, for example, because a device was deleted.
-As of this version, missing subassets in a group are ignored and an error is no longer thrown.
+Previously, an error was thrown for an active model if a subasset of a device group or asset hierarchy no longer existed in the inventory, for example, because a device was deleted.
+As of this version, missing subassets in a device group or asset hierarchy are ignored and an error is no longer thrown.
+However, if the deletion of a subasset results in an empty device group or asset hierarchy, an error is still thrown.
 
 ### Cumulocity IoT transport in Apama 10.15.4
 


### PR DESCRIPTION
Shruti, please make sure that this release note is what you want. I checked the C8Y doc for groups and tried to use the corresponding wording. Looks like they talk about "subassets" now and no longer "child devices" ... ???