### PR TITLE
Link to CD change log for Streaming Analytics.

### DIFF
--- a/content/release-10-18-0/streaming-analytics-10-18-0.md
+++ b/content/release-10-18-0/streaming-analytics-10-18-0.md
@@ -4,3 +4,5 @@ title: Streaming Analytics
 layout: bundle
 ---
 
+The Cumulocity IoT documentation for versions later than 10.18 is available at a new URL.
+Visit a preview of the [Streaming Analytics change log](https://cumulocity.com/docs/changes-analytics/cl-streaming-analytics/) at the new URL.


### PR DESCRIPTION
Added a link to the CD change log at the top of the 10.18 Streaming Analytics release notes as requested by Rob.