### PR TITLE
Release note for PAQ 10.16.0.6

### DIFF
--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_6.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_6.md
@@ -29,11 +29,6 @@ This release upgrades the Apama-ctrl microservice to use Apama 10.15.4.1 (which 
 <td style="text-align:left">PAB-4361</td>
 </tr>
 <tr>
-<td style="text-align:left">Streaming Analytics application</td>
-<td style="text-align:left">To fix a security vulnerability, the Microservice SDK has been updated to version 1016.0.440 to use version 1.2.13 of logback-core and logback-classic.</td>
-<td style="text-align:left">PAB-4373</td>
-</tr>
-<tr>
 <td style="text-align:left">Analytics Builder</td>
 <td style="text-align:left">Asynchronous alarm inputs declared by the <b>Alarm Output</b> blocks were considered for connectivity chains between models, leading to "Internal error : inconsistent chain ID" errors in some scenarios. This has been fixed now.</td>
 <td style="text-align:left">PAB-4395</td>

--- a/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_6.md
+++ b/content/release-10-16-0/streaming-analytics-10-16-0-bundle/10_16_0_6.md
@@ -1,0 +1,43 @@
+---
+weight: 34
+title: Release 10.16.0.6
+layout: redirect
+---
+
+This release upgrades the Apama-ctrl microservice to use Apama 10.15.4.1 (which is the same as Apama 10.15 Fix 17).
+
+### Fixes
+
+<table>
+<colgroup>
+    <col style="width: 15%;">
+    <col style="width: 70%;">
+    <col style="width: 15%;">
+</colgroup>
+<thead>
+<tr>
+<th style="text-align:left">Component</th>
+<th style="text-align:left">Description</th>
+<th style="text-align:left">Issue</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td style="text-align:left">Apama-ctrl microservice</td>
+<td style="text-align:left">For reasons of security and performance, the REST endpoint <code>/service/cep/health</code> no longer returns a comprehensive list of status values. All of the same information is still available from REST endpoints under <code>/service/cep/diagnostics/...</code>.</td>
+<td style="text-align:left">PAB-4361</td>
+</tr>
+<tr>
+<td style="text-align:left">Streaming Analytics application</td>
+<td style="text-align:left">To fix a security vulnerability, the Microservice SDK has been updated to version 1016.0.440 to use version 1.2.13 of logback-core and logback-classic.</td>
+<td style="text-align:left">PAB-4373</td>
+</tr>
+<tr>
+<td style="text-align:left">Analytics Builder</td>
+<td style="text-align:left">Asynchronous alarm inputs declared by the <b>Alarm Output</b> blocks were considered for connectivity chains between models, leading to "Internal error : inconsistent chain ID" errors in some scenarios. This has been fixed now.</td>
+<td style="text-align:left">PAB-4395</td>
+</tr>
+
+</tbody>
+</table>


### PR DESCRIPTION
@ddfourni1 , @skom-sag , this is a first draft. Not sure if all is correct.

PAB-4361:
There's no readme text on the parent defect. But there's a link to the c8y-releasenotes on PAB-4361 itself, for a RN that has been added for 10.17. I've also added that text now for 10.16.0.6. Is this correct?

PAB-4373: 
There's no readme text on the parent defect. But PAB-4373 itself has a readme text, and I've added this. Ok?

PAB-4395:
Took the readme text from the parent.
